### PR TITLE
Fix copyright notice formatting in IndexAction.java

### DIFF
--- a/todolist-goof/todolist-web-struts/src/main/java/io/github/benas/todolist/web/action/IndexAction.java
+++ b/todolist-goof/todolist-web-struts/src/main/java/io/github/benas/todolist/web/action/IndexAction.java
@@ -11,7 +11,7 @@
  *   furnished to do so, subject to the following conditions:
  *
  *   The above copyright notice and this permission notice shall be included in
- *   all copies or substantial portions of the Software.
+ *   all copies or substantial portions of the Software
  *
  *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
Removed a period from the copyright notice in the comments.